### PR TITLE
Sync on startup

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,6 +4,7 @@ export interface ReadeckPluginSettings {
 	username: string,
 	folder: string;
 	lastSyncAt: string;
+	autoSyncOnStartup: boolean;
 	overwrite: boolean;
 	delete: boolean;
 	mode: string;
@@ -50,6 +51,7 @@ export const DEFAULT_SETTINGS: ReadeckPluginSettings = {
 	username: "",
 	folder: "Readeck",
 	lastSyncAt: "",
+	autoSyncOnStartup: true,
 	overwrite: false,
 	delete: false,
 	mode: "text",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -37,6 +37,18 @@ export default class RDPlugin extends Plugin {
 		  })
 
 		this.api = new ReadeckApi(this.settings);
+
+		// Auto sync on startup if configured
+		this.app.workspace.onLayoutReady(async () => {
+			if (this.settings.apiToken === "") {
+				return; // Not logged in
+
+			}
+			if (this.settings.autoSyncOnStartup === false) {
+				return;
+			}
+			await this.getReadeckData();
+		})
 	}
 
 	/*

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -116,6 +116,15 @@ export class RDSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName('Sync on startup')
+			.setDesc('Sync bookmarks automatically when Obsidian starts')
+			.addToggle(toggle => toggle.setValue(this.plugin.settings.autoSyncOnStartup)
+				.onChange(async (value) => {
+					this.plugin.settings.autoSyncOnStartup = value;
+					await this.plugin.saveData(this.plugin.settings);
+				}));
+
+		new Setting(containerEl)
 			.setName('Overwrite if it already exists')
 			.setDesc('Overwrite the note if the bookmark already exists. Warning: the note will be overwritten')
 			.addToggle(toggle => toggle.setValue(this.plugin.settings.overwrite)


### PR DESCRIPTION
This PR makes the plugin auto sync data on application startup and makes this option configurable.

I am migrating over from [readwise reader](https://readwise.io/read) and their obsidian plugin auto-syncs highlights and content whenever you open the app. I found this behavior very intuitive and was quite confused when this plugin did not sync after setup. It took me longer than I want to admit understanding that I need to trigger the sync manually via command.

## TODO
- [ ] Update version